### PR TITLE
Add shared variable to identify models that do not need references

### DIFF
--- a/comet/cli/compare.py
+++ b/comet/cli/compare.py
@@ -44,6 +44,7 @@ import json
 from typing import Union
 
 import numpy as np
+from comet.cli.score import _REFLESS_MODELS
 from comet.download_utils import download_model
 from comet.models import available_metrics, load_from_checkpoint
 from jsonargparse import ArgumentParser
@@ -94,7 +95,7 @@ def compare_command() -> None:
     cfg = parser.parse_args()
     seed_everything(cfg.seed_everything)
 
-    if (cfg.references is None) and ("refless" not in cfg.model):
+    if (cfg.references is None) and (not any([i in cfg.model for i in _REFLESS_MODELS])):
         parser.error("{} requires -r/--references.".format(cfg.model))
 
     model_path = (

--- a/comet/cli/compare.py
+++ b/comet/cli/compare.py
@@ -95,7 +95,9 @@ def compare_command() -> None:
     cfg = parser.parse_args()
     seed_everything(cfg.seed_everything)
 
-    if (cfg.references is None) and (not any([i in cfg.model for i in _REFLESS_MODELS])):
+    if (cfg.references is None) and (
+        not any([i in cfg.model for i in _REFLESS_MODELS])
+    ):
         parser.error("{} requires -r/--references.".format(cfg.model))
 
     model_path = (

--- a/comet/cli/score.py
+++ b/comet/cli/score.py
@@ -79,7 +79,9 @@ def score_command() -> None:
     cfg = parser.parse_args()
     seed_everything(cfg.seed_everything)
 
-    if (cfg.references is None) and (not any([i in cfg.model for i in _REFLESS_MODELS])):
+    if (cfg.references is None) and (
+        not any([i in cfg.model for i in _REFLESS_MODELS])
+    ):
         parser.error("{} requires -r/--references.".format(cfg.model))
 
     model_path = (

--- a/comet/cli/score.py
+++ b/comet/cli/score.py
@@ -40,6 +40,9 @@ from jsonargparse.typing import Path_fr
 from pytorch_lightning import seed_everything
 
 
+_REFLESS_MODELS = ["comet-qe"]
+
+
 def score_command() -> None:
     parser = ArgumentParser(description="Command for scoring MT systems.")
     parser.add_argument("-s", "--sources", type=Path_fr, required=True)
@@ -76,7 +79,7 @@ def score_command() -> None:
     cfg = parser.parse_args()
     seed_everything(cfg.seed_everything)
 
-    if (cfg.references is None) and ("comet-qe" not in cfg.model):
+    if (cfg.references is None) and (not any([i in cfg.model for i in _REFLESS_MODELS])):
         parser.error("{} requires -r/--references.".format(cfg.model))
 
     model_path = (


### PR DESCRIPTION
Fixes #24

I just added a variable that contains identifiers (substrings) for the models that do not need references. This is shared between the `score` and `compare` cli interfaces. Ran the `black` code formatter.