### PR TITLE
Adds --quiet flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ WMT test sets via [SacreBLEU](https://github.com/mjpost/sacrebleu):
 comet-score -d wmt20:en-de -t PATH/TO/TRANSLATIONS
 ```
 
+The default setting of `comet-score` prints the score for each segment individually. If you are only interested in the score for the whole dataset (computed as the average of the segment scores), you can use the `--quiet` flag.
+
+```bash
+comet-score -s src.de -t hyp1.en -r ref.en --quiet
+```
+
 You can select another model/metric with the --model flag and for reference-free (QE-as-a-metric) models you don't need to pass a reference.
 
 ```bash

--- a/comet/cli/score.py
+++ b/comet/cli/score.py
@@ -44,6 +44,7 @@ optional arguments:
                         (type: Union[bool, int], default: False)
   --seed_everything SEED_EVERYTHING
                         Prediction seed. (type: int, default: 12)
+  --quiet               Prints only the average COMET score for the whole dataset. (default: False)
 """
 import itertools
 import json
@@ -134,6 +135,11 @@ def score_command() -> None:
         "--print_cache_info",
         action="store_true",
         help="Print information about COMET cache.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Prints only the average COMET score for the whole dataset.",
     )
     cfg = parser.parse_args()
     seed_everything(cfg.seed_everything)
@@ -294,17 +300,19 @@ def score_command() -> None:
             data[files[j]][i]["COMET"] = seg_scores[j][i]
             if cfg.mc_dropout:
                 data[files[j]][i]["variance"] = std_scores[j][i]
-                print(
-                    "{}\tSegment {}\tscore: {:.4f}\tvariance: {:.4f}".format(
-                        files[j], i, seg_scores[j][i], std_scores[j][i]
+                if not cfg.quiet:
+                    print(
+                        "{}\tSegment {}\tscore: {:.4f}\tvariance: {:.4f}".format(
+                            files[j], i, seg_scores[j][i], std_scores[j][i]
+                        )
                     )
-                )
             else:
-                print(
-                    "{}\tSegment {}\tscore: {:.4f}".format(
-                        files[j], i, seg_scores[j][i]
+                if not cfg.quiet:
+                    print(
+                        "{}\tSegment {}\tscore: {:.4f}".format(
+                            files[j], i, seg_scores[j][i]
+                        )
                     )
-                )
 
     for j in range(len(files)):
         print("{}\tscore: {:.4f}".format(files[j], sys_scores[j]))


### PR DESCRIPTION
Addresses issue #56.

Instead of printing the individual COMET score for each segment, using `--quiet` flag will display the average score for the whole dataset. README has also been updated to reflect these changes.