### PR TITLE
Comet compare for multiple systems.

### DIFF
--- a/comet/cli/compare.py
+++ b/comet/cli/compare.py
@@ -47,7 +47,12 @@ optional arguments:
 import json
 import multiprocessing
 import os
-from typing import Union
+from typing import (
+        Dict,
+        Generator,
+        List,
+        Union,
+        )
 
 import numpy as np
 import torch
@@ -58,6 +63,7 @@ from jsonargparse import ArgumentParser
 from jsonargparse.typing import Path_fr
 from pytorch_lightning import seed_everything
 from scipy import stats
+from argparse import Namespace
 
 _REFLESS_MODELS = ["comet-qe"]  # All reference-free metrics are named with 'comet-qe'
 # Due to small numerical differences in scores we consider that any system comparison
@@ -65,12 +71,183 @@ _REFLESS_MODELS = ["comet-qe"]  # All reference-free metrics are named with 'com
 EPS = 0.001
 
 
-def compare_command() -> Union[None, int]:
-    parser = ArgumentParser(description="Command for comparing two MT systems.")
+def display_ttest_result(data: Dict) -> None:
+    """
+    Print out the T-test results for a system pair.
+    """
+    print("==========================")
+    print("x_name:", data["x_name"].rel_path)
+    print("y_name:", data["y_name"].rel_path)
+
+    print("\nBootstrap Resampling Results:")
+    for k, v in data["bootstrap_resampling"].items():
+        print("{}:\t{:.4f}".format(k, v))
+
+    print("\nPaired T-Test Results:")
+    for k, v in data["paired_t-test"].items():
+        print("{}:\t{:.4f}".format(k, v))
+
+    x_seg_scores = data["bootstrap_resampling"]["x-mean"]
+    y_seg_scores = data["bootstrap_resampling"]["y-mean"]
+    best_system = (
+        data["x_name"].rel_path
+        if x_seg_scores > y_seg_scores
+        else data["y_name"].rel_path
+    )
+    worse_system = (
+        data["x_name"].rel_path
+        if x_seg_scores < y_seg_scores
+        else data["y_name"].rel_path
+    )
+    if data["paired_t-test"]["p_value"] <= 0.05:
+        print("Null hypothesis rejected according to t-test.")
+        print(f"Scores differ significantly across samples.")
+        print(f"{best_system} outperforms {worse_system}.")
+    else:
+        print("Null hypothesis can't be rejected.\nBoth systems have equal averages.")
+
+
+def calculate_t_test(x_sys_scores: np.ndarray, y_sys_scores: np.ndarray, x_name: Path_fr, y_name: Path_fr) -> Dict:
+    """
+    Calculate T-test score, wins and ties for a system pair.
+    x_sys_scores: array of num_splits comet scores for system x
+    y_sys_scores: array of num_splits comet scores for system y
+    x_name: system x's name
+    y_name: system y's name
+    num_split: number of splits
+    """
+    num_splits = x_sys_scores.shape[0]
+    delta = x_sys_scores - y_sys_scores
+    ties = np.absolute(delta)
+    ties = float(len(ties[ties<EPS]))
+    x_wins = float(len(delta[delta>=EPS]))
+    y_wins = float(len(delta[delta<=-EPS]))
+    t_test_result = stats.ttest_rel(x_sys_scores, y_sys_scores)
+    return {
+            "x_name": x_name,
+            "y_name": y_name,
+            "bootstrap_resampling": {
+                "x-mean": float(np.mean(x_sys_scores)),
+                "y-mean": float(np.mean(y_sys_scores)),
+                "ties (%)":   ties / num_splits,
+                "x_wins (%)": x_wins / num_splits,
+                "y_wins (%)": y_wins / num_splits,
+                },
+            "paired_t-test": {
+                "statistic": float(t_test_result.statistic),
+                "p_value": float(t_test_result.pvalue),
+                },
+            }
+
+
+def pairwise_t_test(sys_scores: np.ndarray, systems: List[Path_fr]) -> Generator[Dict, None, None]:
+    """
+    Calculates the t_test between all systems' permutations.
+    sys_scores: comet scores [num_systems x num_splits]
+    """
+    assert sys_scores.shape[0] == len(systems), "Each system should have its sys_score."
+
+    from itertools import permutations
+    pairs = permutations(zip(systems, sys_scores), 2)
+    for (x_name, x_sys_scores), (y_name, y_sys_scores) in pairs:
+        yield calculate_t_test(
+                x_sys_scores,
+                y_sys_scores,
+                x_name,
+                y_name,
+                )
+
+
+def bootstrap_resampling(seg_scores: np.ndarray, sample_size: int, num_splits: int):
+    """
+    seg_scores: comet scores for each systems' translation, aka a comet score matrix [num_systems X num_sentences]
+    sample_size:
+    num_splits:
+    Returns a comet score matrix [num_systems X num_splits]
+    """
+    population_size = seg_scores.shape[1]
+    # Subsample the gold and system outputs (with replacement)
+    subsample_ids = np.random.choice(population_size, size=(sample_size, num_splits), replace=True)
+    subsamples    = np.take(seg_scores, subsample_ids, axis=1) # num_systems x sample_size x num_splits
+    sys_scores    = np.mean(subsamples, axis=1) # num_systems x num_splits
+
+    return sys_scores
+
+
+def score(cfg: Namespace, systems: List[Dict[str,List[str]]]) -> np.ndarray:
+    """
+    Scores each systems with a given model.
+    Returns a comet score matrix [num_systems X num_sentences]
+    """
+    model = load_from_checkpoint(cfg.model_path)
+    model.eval()
+
+    if not cfg.disable_cache:
+        model.set_embedding_cache()
+
+    if cfg.print_cache_info:
+        print(model.retrieve_sentence_embedding.cache_info())
+
+    # Create a single list that contains all systems' source, reference & translation.
+    samples = [
+            dict(zip(system, values))
+            for system in systems
+            for values in zip(*system.values())
+            ]
+
+    if cfg.gpus > 1 and cfg.accelerator == "ddp":
+        #raise NotImplementedError()
+        gather_outputs = [
+            None for _ in range(cfg.gpus)
+        ]  # Only necessary for multigpu DDP
+        outputs = model.predict(
+            samples=samples,
+            batch_size=cfg.batch_size,
+            gpus=cfg.gpus,
+            progress_bar=(not cfg.disable_bar),
+            accelerator=cfg.accelerator,
+            num_workers=cfg.num_workers,
+            length_batching=(not cfg.disable_length_batching),
+        )
+        seg_scores = outputs[0]
+        torch.distributed.all_gather_object(gather_outputs, seg_scores)
+        torch.distributed.barrier()  # Waits for all processes
+        if torch.distributed.get_rank() == 0:
+            seg_scores = [
+                o[i] for i in range(len(gather_outputs[0])) for o in gather_outputs
+            ]
+        else:
+            # TODO: what should be return here?
+            return 0
+
+    else:  # This maximizes cache hits because batches will be equal!
+        seg_scores, _ = model.predict(
+            samples=samples,
+            batch_size=cfg.batch_size,
+            gpus=cfg.gpus,
+            progress_bar=(not cfg.disable_bar),
+            accelerator=cfg.accelerator,
+            num_workers=cfg.num_workers,
+            length_batching=(not cfg.disable_length_batching),
+        )
+
+    n = len(systems[0]['src'])
+    # [grouper](https://docs.python.org/3/library/itertools.html#itertools-recipes)
+    seg_scores = list(zip(*[iter(seg_scores)] * n))
+
+    seg_scores = np.array(seg_scores, dtype='float32') # num_systems x num_translations
+
+    return seg_scores
+
+
+def get_cfg() -> Namespace:
+    """
+    Parse the CLI options and arguments.
+    """
+    parser = ArgumentParser(description="Command for comparing multiple MT systems.")
     parser.add_argument("-s", "--sources", type=Path_fr)
-    parser.add_argument("-x", "--system_x", type=Path_fr, required=True)
-    parser.add_argument("-y", "--system_y", type=Path_fr, required=True)
     parser.add_argument("-r", "--references", type=Path_fr)
+    parser.add_argument("systems", nargs="*", type=Path_fr)
     parser.add_argument("-d", "--sacrebleu_dataset", type=str)
     parser.add_argument("--batch_size", type=int, default=8)
     parser.add_argument("--gpus", type=int, default=1)
@@ -147,8 +324,8 @@ def compare_command() -> Union[None, int]:
         action="store_true",
         help="Print information about COMET cache.",
     )
+
     cfg = parser.parse_args()
-    seed_everything(cfg.seed_everything)
 
     if cfg.sources is None and cfg.sacrebleu_dataset is None:
         parser.error(f"You must specify a source (-s) or a sacrebleu dataset (-d)")
@@ -161,7 +338,9 @@ def compare_command() -> Union[None, int]:
 
         try:
             testset, langpair = cfg.sacrebleu_dataset.rsplit(":", maxsplit=1)
+            # TODO: get_source_file() is not defined.
             cfg.sources = Path_fr(get_source_file(testset, langpair))
+            # TODO: get_reference_files() is not defined.
             cfg.references = Path_fr(get_reference_files(testset, langpair)[0])
         except ValueError:
             parser.error(
@@ -181,179 +360,79 @@ def compare_command() -> Union[None, int]:
         )
 
     if cfg.model.endswith(".ckpt") and os.path.exists(cfg.model):
-        model_path = cfg.model
+        cfg.model_path = cfg.model
     elif cfg.model in available_metrics:
-        model_path = download_model(cfg.model, saving_directory=cfg.model_storage_path)
+        cfg.model_path = download_model(cfg.model, saving_directory=cfg.model_storage_path)
     else:
         parser.error(
             "{} is not a valid checkpoint path or model choice. Choose from {}".format(
                 cfg.model, list(available_metrics.keys())
             )
         )
-    model = load_from_checkpoint(model_path)
-    model.eval()
 
-    if not cfg.disable_cache:
-        model.set_embedding_cache()
+    return cfg
+
+
+def compare_command() -> None:
+    """
+    CLI that uses comet to compare multiple systems in a pairwise manner.
+    """
+    cfg = get_cfg()
+    seed_everything(cfg.seed_everything)
+
+    assert len(cfg.systems) > 1, "You must provide at least 2 systems"
 
     with open(cfg.sources()) as fp:
         sources = [line.strip() for line in fp.readlines()]
 
-    with open(cfg.system_x()) as fp:
-        system_x = [line.strip() for line in fp.readlines()]
+    translations = []
+    for system in cfg.systems:
+        with open(system, mode='r', encoding='UTF-8') as fp:
+            translations.append([line.strip() for line in fp.readlines()])
 
-    with open(cfg.system_y()) as fp:
-        system_y = [line.strip() for line in fp.readlines()]
-
+    references = None
     if "comet-qe" in cfg.model:
-        system_x = {"src": sources, "mt": system_x}
-        system_y = {"src": sources, "mt": system_y}
+        systems = [{"src": sources, "mt": system} for system in translations]
     else:
         with open(cfg.references()) as fp:
             references = [line.strip() for line in fp.readlines()]
-        system_x = {"src": sources, "mt": system_x, "ref": references}
-        system_y = {"src": sources, "mt": system_y, "ref": references}
+        systems = [{"src": sources, "mt": system, "ref": references} for system in translations]
 
-    system_x = [dict(zip(system_x, t)) for t in zip(*system_x.values())]
-    system_y = [dict(zip(system_y, t)) for t in zip(*system_y.values())]
+    seg_scores = score(cfg, systems)
 
-    if cfg.gpus > 1 and cfg.accelerator == "ddp":
-        gather_outputs = [
-            None for _ in range(cfg.gpus)
-        ]  # Only necessary for multigpu DDP
-        seperator_index = len(system_x)
-        data = system_x + system_y
-        outputs = model.predict(
-            samples=data,
-            batch_size=cfg.batch_size,
-            gpus=cfg.gpus,
-            progress_bar=(not cfg.disable_bar),
-            accelerator=cfg.accelerator,
-            num_workers=cfg.num_workers,
-            length_batching=(not cfg.disable_length_batching),
-        )
-        seg_scores = outputs[0]
-        torch.distributed.all_gather_object(gather_outputs, seg_scores)
-        torch.distributed.barrier()  # Waits for all processes
-        if torch.distributed.get_rank() == 0:
-            seg_scores = [
-                o[i] for i in range(len(gather_outputs[0])) for o in gather_outputs
-            ]
-        else:
-            return 0
-
-        x_seg_scores = seg_scores[:seperator_index]
-        y_seg_scores = seg_scores[seperator_index:]
-
-    else:  # This maximizes cache hits because batches will be equal!
-        x_seg_scores, _ = model.predict(
-            samples=system_x,
-            batch_size=cfg.batch_size,
-            gpus=cfg.gpus,
-            progress_bar=(not cfg.disable_bar),
-            accelerator=cfg.accelerator,
-            num_workers=cfg.num_workers,
-            length_batching=(not cfg.disable_length_batching),
-        )
-        y_seg_scores, _ = model.predict(
-            samples=system_y,
-            batch_size=cfg.batch_size,
-            gpus=cfg.gpus,
-            progress_bar=(not cfg.disable_bar),
-            accelerator=cfg.accelerator,
-            num_workers=cfg.num_workers,
-            length_batching=(not cfg.disable_length_batching),
-        )
-
-    data = []
-    for i, (x_score, y_score) in enumerate(zip(x_seg_scores, y_seg_scores)):
-        if not cfg.quiet:
-            print(
-                "Segment {}\tsystem_x score: {:.4f}\tsystem_y score: {:.4f}".format(
-                    i, x_score, y_score
-                )
+    population_size = seg_scores.shape[1]
+    sys_scores = bootstrap_resampling(
+            seg_scores,
+            sample_size=max(int(population_size * cfg.sample_ratio), 1),
+            num_splits=cfg.num_splits,
             )
-        data.append(
-            {
-                "src": system_x[i]["src"],
-                "system_x": {"mt": system_x[i]["mt"], "score": x_score},
-                "system_y": {"mt": system_y[i]["mt"], "score": y_score},
+
+    t_test_results = list(pairwise_t_test(sys_scores, cfg.systems))
+    for data in t_test_results:
+        display_ttest_result(data)
+
+    info = {
+            "model": cfg.model,
+            "t_test": t_test_results,
+            "source": sources,
+            "systems": [
+                    {
+                        "name": name,
+                        "mt": trans,
+                        "scores": scores.tolist(),
+                    } for name, trans, scores in zip(cfg.systems, translations, seg_scores)
+                ],
             }
-        )
-        if "comet-qe" not in cfg.model:
-            data[-1]["ref"] = system_y[i]["ref"]
-
-    n = len(sources)
-    ids = list(range(n))
-    sample_size = max(int(n * cfg.sample_ratio), 1)
-
-    x_sys_scores, y_sys_scores = [], []
-    win_count = [0, 0, 0]
-    for _ in range(cfg.num_splits):
-        # Subsample the gold and system outputs (with replacement)
-        subsample_ids = np.random.choice(ids, size=sample_size, replace=True)
-        subsample_x_scr = sum([x_seg_scores[i] for i in subsample_ids]) / sample_size
-        subsample_y_scr = sum([y_seg_scores[i] for i in subsample_ids]) / sample_size
-
-        if abs(subsample_x_scr - subsample_y_scr) < EPS:  # TIE
-            win_count[2] += 1
-        elif subsample_x_scr > subsample_y_scr:  # X WIN
-            win_count[0] += 1
-        else:  # subsample_y_scr > subsample_x_scr: # Y WIN
-            win_count[1] += 1
-
-        x_sys_scores.append(subsample_x_scr)
-        y_sys_scores.append(subsample_y_scr)
-
-    t_test_result = stats.ttest_rel(np.array(x_seg_scores), np.array(y_seg_scores))
-    data.insert(
-        0,
-        {
-            "bootstrap_resampling": {
-                "x-mean": np.mean(np.array(x_sys_scores)),
-                "y-mean": np.mean(np.array(y_sys_scores)),
-                "ties (%)": win_count[2] / sum(win_count),
-                "x_wins (%)": win_count[0] / sum(win_count),
-                "y_wins (%)": win_count[1] / sum(win_count),
-            },
-            "paired_t-test": {
-                "statistic": t_test_result.statistic,
-                "p_value": t_test_result.pvalue,
-            },
-        },
-    )
-    print("\nBootstrap Resampling Results:")
-    for k, v in data[0]["bootstrap_resampling"].items():
-        print("{}:\t{:.4f}".format(k, v))
-
-    print("\nPaired T-Test Results:")
-    for k, v in data[0]["paired_t-test"].items():
-        print("{}:\t{:.4f}".format(k, v))
-
-    best_system = (
-        cfg.system_x.rel_path
-        if sum(x_seg_scores) > sum(y_seg_scores)
-        else cfg.system_y.rel_path
-    )
-    worse_system = (
-        cfg.system_x.rel_path
-        if sum(x_seg_scores) < sum(y_seg_scores)
-        else cfg.system_y.rel_path
-    )
-    if data[0]["paired_t-test"]["p_value"] <= 0.05:
-        print("Null hypothesis rejected according to t-test.")
-        print(f"Scores differ significantly across samples.")
-        print(f"{best_system} outperforms {worse_system}.")
-    else:
-        print("Null hypothesis can't be rejected.\nBoth systems have equal averages.")
+    if references is not None:
+        info["reference"] = references
 
     if isinstance(cfg.to_json, str):
         with open(cfg.to_json, "w") as outfile:
-            json.dump(data, outfile, ensure_ascii=False, indent=4)
+            json.dump(info, outfile, ensure_ascii=False, indent=4)
         print("Predictions saved in: {}.".format(cfg.to_json))
 
-    if cfg.print_cache_info:
-        print(model.retrieve_sentence_embedding.cache_info())
+
+
 
 
 if __name__ == "__main__":

--- a/comet/cli/compare.py
+++ b/comet/cli/compare.py
@@ -147,8 +147,8 @@ def pairwise_t_test(sys_scores: np.ndarray, systems: List[Path_fr]) -> Generator
     """
     assert sys_scores.shape[0] == len(systems), "Each system should have its sys_score."
 
-    from itertools import permutations
-    pairs = permutations(zip(systems, sys_scores), 2)
+    from itertools import combinations
+    pairs = combinations(zip(systems, sys_scores), 2)
     for (x_name, x_sys_scores), (y_name, y_sys_scores) in pairs:
         yield calculate_t_test(
                 x_sys_scores,


### PR DESCRIPTION
Hi,
  I would like to propose to modify `compare.py` to allow comparing more than 2 systems at once.  The main changes are that we need to accept possibly more than 2 systems, perform bootstrap resampling, in parallel on all systems and calculate pairwise T-tests.

Doing pairwise T-test for multiple systems can be expensive as there is a substantial over head when we start the script to load the imported modules.  Also, calculating `comet` scores needs only to be done once per systems.  The actual T-test is quite fast.