### PR TITLE
Fix error with custom QE COMET

### DIFF
--- a/comet/cli/score.py
+++ b/comet/cli/score.py
@@ -58,12 +58,11 @@ import numpy as np
 import torch
 from comet.download_utils import download_model
 from comet.models import available_metrics, load_from_checkpoint
+from comet.models.regression.referenceless import ReferencelessRegression
 from jsonargparse import ArgumentParser
 from jsonargparse.typing import Path_fr
 from pytorch_lightning import seed_everything
 from sacrebleu.utils import get_reference_files, get_source_file
-
-_REFLESS_MODELS = ["comet-qe"]
 
 
 def score_command() -> None:
@@ -166,13 +165,6 @@ def score_command() -> None:
             print("SacreBLEU error:", e, file=sys.stderr)
             sys.exit(1)
 
-    if (cfg.references is None) and (
-        not any([i in cfg.model for i in _REFLESS_MODELS])
-    ):
-        parser.error(
-            "{} requires -r/--references or -d/--sacrebleu_dataset.".format(cfg.model)
-        )
-
     if cfg.model.endswith(".ckpt") and os.path.exists(cfg.model):
         model_path = cfg.model
     elif cfg.model in available_metrics:
@@ -186,6 +178,11 @@ def score_command() -> None:
     model = load_from_checkpoint(model_path)
     model.eval()
 
+    if (cfg.references is None) and (not isinstance(model, ReferencelessRegression)):
+        parser.error(
+            "{} requires -r/--references or -d/--sacrebleu_dataset.".format(cfg.model)
+        )
+
     if not cfg.disable_cache:
         model.set_embedding_cache()
 
@@ -197,7 +194,7 @@ def score_command() -> None:
         with open(path_fr(), encoding="utf-8") as fp:
             translations.append([line.strip() for line in fp.readlines()])
 
-    if "comet-qe" in cfg.model:
+    if isinstance(model, ReferencelessRegression):
         data = {"src": [sources for _ in translations], "mt": translations}
     else:
         with open(cfg.references(), encoding="utf-8") as fp:

--- a/comet/cli/score.py
+++ b/comet/cli/score.py
@@ -178,7 +178,7 @@ def score_command() -> None:
     model = load_from_checkpoint(model_path)
     model.eval()
 
-    if (cfg.references is None) and (not isinstance(model, ReferencelessRegression)):
+    if (cfg.references is None) and (not model.is_referenceless()):
         parser.error(
             "{} requires -r/--references or -d/--sacrebleu_dataset.".format(cfg.model)
         )
@@ -194,7 +194,7 @@ def score_command() -> None:
         with open(path_fr(), encoding="utf-8") as fp:
             translations.append([line.strip() for line in fp.readlines()])
 
-    if isinstance(model, ReferencelessRegression):
+    if model.is_referenceless():
         data = {"src": [sources for _ in translations], "mt": translations}
     else:
         with open(cfg.references(), encoding="utf-8") as fp:

--- a/comet/models/base.py
+++ b/comet/models/base.py
@@ -194,6 +194,10 @@ class CometModel(ptl.LightningModule, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def forward(self, *args, **kwargs) -> Dict[str, torch.Tensor]:
         pass
+    
+    @abc.abstractmethod
+    def is_referenceless(self) -> bool:
+        pass
 
     def freeze_encoder(self) -> None:
         logger.info("Encoder model frozen.")

--- a/comet/models/ranking/ranking_metric.py
+++ b/comet/models/ranking/ranking_metric.py
@@ -93,6 +93,9 @@ class RankingMetric(CometModel):
     def init_metrics(self):
         self.train_metrics = WMTKendall(prefix="train")
         self.val_metrics = WMTKendall(prefix="val")
+    
+    def is_referenceless(self) -> bool:
+        return False
 
     @property
     def loss(self):

--- a/comet/models/regression/referenceless.py
+++ b/comet/models/regression/referenceless.py
@@ -97,6 +97,9 @@ class ReferencelessRegression(RegressionMetric):
             dropout=self.hparams.dropout,
             final_activation=self.hparams.final_activation,
         )
+    
+    def is_referenceless(self) -> bool:
+        return True
 
     def prepare_sample(
         self, sample: List[Dict[str, Union[str, float]]], inference: bool = False

--- a/comet/models/regression/regression_metric.py
+++ b/comet/models/regression/regression_metric.py
@@ -103,6 +103,9 @@ class RegressionMetric(CometModel):
     def init_metrics(self):
         self.train_metrics = RegressionMetrics(prefix="train")
         self.val_metrics = RegressionMetrics(prefix="val")
+    
+    def is_referenceless(self) -> bool:
+        return False
 
     def configure_optimizers(
         self,


### PR DESCRIPTION
When a custom QE metric is trained, the scorer.py gives the error:
`parser.error("{} requires -r/--references or -d/--sacrebleu_dataset.".format(cfg.model))`

This happens because it is currently comparing the given model name with `_REFLESS_MODELS = ["comet-qe"]` only, not allowing to use custom QE metrics.