### PR TITLE
Apple Silicon (M1) support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ comet-mbr = 'comet.cli.mbr:mbr_command'
 [tool.poetry.dependencies]
 python = ">=3.7.0,<4.0.0"
 sentencepiece = "^0.1.96"
-pandas = "1.1.5"
+pandas = "1.4.1"
 transformers = ">=4.8"
 pytorch-lightning = "1.6.4"
 jsonargparse = "3.13.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sentencepiece==0.1.96
-pandas==1.1.5
+pandas==1.4.1
 transformers>=4.8
 pytorch-lightning==1.6.4
 jsonargparse==3.13.1


### PR DESCRIPTION
It's currently impossible to install the package locally on Apple M1, there are a lot of errors related to architecture difference in Pandas < 1.4. 

This PR fixes the problem by upgrading Pandas to the lowest supported version of ARM64 processors. Tested with different cases, it works as it worked, also afaik there are no breaking changes between 1.1.5 and 1.4.1.