### PR TITLE
Update get_cache_folder for Windows

### DIFF
--- a/comet/download_utils.py
+++ b/comet/download_utils.py
@@ -30,8 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_cache_folder():
-    home_dir = Path(os.environ["HOME"]) if "HOME" in os.environ else Path.home()
-    cache_directory = home_dir / ".cache" / "torch" / "unbabel_comet"
+    cache_directory = Path.home() / ".cache" / "torch" / "unbabel_comet"
     if not cache_directory.exists():
         cache_directory.mkdir(exist_ok=True, parents=True)
 

--- a/comet/download_utils.py
+++ b/comet/download_utils.py
@@ -18,6 +18,7 @@ import os
 import subprocess
 import urllib.request
 import zipfile
+from pathlib import Path
 from typing import List
 from urllib.parse import urlparse
 
@@ -29,13 +30,12 @@ logger = logging.getLogger(__name__)
 
 
 def get_cache_folder():
-    if "HOME" in os.environ:
-        cache_directory = os.environ["HOME"] + "/.cache/torch/unbabel_comet/"
-        if not os.path.exists(cache_directory):
-            os.makedirs(cache_directory)
-        return cache_directory
-    else:
-        raise Exception("HOME environment variable is not defined.")
+    home_dir = Path(os.environ["HOME"]) if "HOME" in os.environ else Path.home()
+    cache_directory = home_dir / ".cache" / "torch" / "unbabel_comet"
+    if not cache_directory.exists():
+        cache_directory.mkdir(exist_ok=True, parents=True)
+
+    return str(cache_directory)
 
 
 def _reporthook(t):


### PR DESCRIPTION
Currently, the `get_cache_folder` utility tries to rely on the env `HOME`. But this variable is not regularly set on Windows. Luckily Python comes with some cross-platform defaults to get a user's home directory.

This PR makes a small update to use pathlib's `Path.home`, which in turn will access `os.path.expanduser`. Here, the user's home will be resolved. It will target the `HOME` env variable if it exists (as was implemented in COMET before) and otherwise it will try to find the user's home another way.

This should make the code base more compatible with Windows, although I have not tested yet if this would make the whole lib work on Windows.