### PR TITLE
Allow for pandas major version 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ comet-mbr = 'comet.cli.mbr:mbr_command'
 [tool.poetry.dependencies]
 python = "^3.8.0"
 sentencepiece = "^0.1.96"
-pandas = "^1.4.1"
+pandas = ">=1.4.1"
 transformers = "^4.17"
 pytorch-lightning = "^1.6.4"
 jsonargparse = "3.13.1"


### PR DESCRIPTION
While COMET 1.1.3 supported pandas 2, this was more restricted in COMET 2. However, I ran all the tests with pandas==2.0.1 and that works fine. So I believe that pandas 2 can be allowed again.

closes #130 