### PR TITLE
Allow to specify `local_files_only` param when downloading a snapshot

### DIFF
--- a/comet/models/__init__.py
+++ b/comet/models/__init__.py
@@ -35,9 +35,10 @@ str2model = {
 
 def download_model(
     model: str, 
-    saving_directory: Union[str, Path, None] = None
+    saving_directory: Union[str, Path, None] = None,
+    local_files_only: bool = False
 ) -> str:
-    model_path = snapshot_download(repo_id=model, cache_dir=saving_directory)
+    model_path = snapshot_download(repo_id=model, cache_dir=saving_directory, local_files_only=local_files_only)
     checkpoint_path = os.path.join(*[model_path, "checkpoints", "model.ckpt"])
     return checkpoint_path
 

--- a/comet/models/__init__.py
+++ b/comet/models/__init__.py
@@ -34,11 +34,13 @@ str2model = {
 }
 
 def download_model(
-    model: str, 
+    model: str,
     saving_directory: Union[str, Path, None] = None,
     local_files_only: bool = False
 ) -> str:
-    model_path = snapshot_download(repo_id=model, cache_dir=saving_directory, local_files_only=local_files_only)
+    model_path = snapshot_download(
+        repo_id=model, cache_dir=saving_directory, local_files_only=local_files_only
+    )
     checkpoint_path = os.path.join(*[model_path, "checkpoints", "model.ckpt"])
     return checkpoint_path
 


### PR DESCRIPTION
This PR adds `local_files_only` parameter to `download_model` function which allows to reuse local models without having to request huggingface domain every COMET run.