### PR TITLE
Fix multi-gpu inference

### DIFF
--- a/comet/cli/score.py
+++ b/comet/cli/score.py
@@ -59,6 +59,7 @@ from pytorch_lightning import seed_everything
 from sacrebleu.utils import get_reference_files, get_source_file
 
 from comet import download_model, load_from_checkpoint
+from comet.models.utils import split_sequence_into_sublists
 
 
 def score_command() -> None:
@@ -208,7 +209,7 @@ def score_command() -> None:
             seg_scores = np.array_split(seg_scores, len(cfg.translations))
             sys_scores = [sum(split) / len(split) for split in seg_scores]
             data = np.array_split(data, len(cfg.translations))
-            errors = np.array_split(outputs.metadata.errors, len(cfg.translations))
+            errors = split_sequence_into_sublists(errors, len(cfg.translations))
         else:
             sys_scores = [
                 outputs.system_score,
@@ -249,7 +250,7 @@ def score_command() -> None:
     for i in range(len(data[files[0]])):  # loop over (src, ref)
         for j in range(len(files)):  # loop of system
             data[files[j]][i]["COMET"] = seg_scores[j][i]
-            if errors:
+            if errors and errors[j] and errors[j][i]:
                 data[files[j]][i]["errors"] = errors[j][i]
                 
             if not cfg.only_system:

--- a/comet/models/predict_writer.py
+++ b/comet/models/predict_writer.py
@@ -97,7 +97,7 @@ class CustomWriter(BasePredictionWriter):
         files = sorted(os.listdir(self.output_dir))
         pred = flatten_predictions(
             [
-                flatten_predictions(torch.load(os.path.join(self.output_dir, f))[0])
+                flatten_predictions(torch.load(os.path.join(self.output_dir, f)))
                 for f in files
                 if "pred" in f
             ]

--- a/comet/models/utils.py
+++ b/comet/models/utils.py
@@ -183,3 +183,15 @@ def restore_list_order(sorted_list, sort_ids):
     for i, s in zip(sort_ids, sorted_list):
         unsorted_list[i] = s
     return unsorted_list
+
+
+def split_sequence_into_sublists(sequence, n):
+    elements_per_chunk, remainder = divmod(len(sequence), n)
+    return [
+        sequence[
+            i * elements_per_chunk
+            + min(i, remainder) : (i + 1) * elements_per_chunk
+            + min(i + 1, remainder)
+        ]
+        for i in range(n)
+    ]


### PR DESCRIPTION
This PR fixes multi-gpu inference, as reported in #177 
While trying to fix it, I found some more errors related to proper handling of error spans metadata (with XCOMET models).

I tried out the fixes with XCOMET-XL and wmt22-comet-da models  - but it could use some more testing (the code could also be somewhat improved, but I haven't mastered the COMET codebase yet ;) )

