### PR TITLE
[Fix] configure multiprocessing context in Apple Silicon

### DIFF
--- a/comet/models/base.py
+++ b/comet/models/base.py
@@ -622,6 +622,7 @@ class CometModel(ptl.LightningModule, metaclass=abc.ABCMeta):
             sampler=sampler,
             collate_fn=self.prepare_for_inference,
             num_workers=num_workers,
+            multiprocessing_context="fork" if torch.backends.mps.is_available() else None,
         )
         if gpus > 1:
             pred_writer = CustomWriter()


### PR DESCRIPTION
To fix issue described in https://github.com/Unbabel/COMET/issues/235.

After fixing the command could run smoothly
```
Predicting DataLoader 0: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.43s/it]
hyp.txt Segment 0       score: 0.8547
hyp.txt score: 0.8547

```