### PR TITLE
Fix model typo in train CLI - RankingMetric

### DIFF
--- a/comet/cli/train.py
+++ b/comet/cli/train.py
@@ -142,7 +142,7 @@ def initialize_model(configs):
         )
         if configs.load_from_checkpoint is not None:
             logger.info(f"Loading weights from {configs.load_from_checkpoint}.")
-            model = ReferencelessRegression.load_from_checkpoint(
+            model = RankingMetric.load_from_checkpoint(
                 checkpoint_path=configs.load_from_checkpoint,
                 strict=configs.strict_load,
                 **namespace_to_dict(configs.ranking_metric.init_args),


### PR DESCRIPTION
This seems like a simple typo where `RankingMetric` should be loaded instead of `ReferencelessRegression`. Maybe this wasn't noticed before because the ranking metric is not used that often?