### PR TITLE
Fix compare method for reference free models

### DIFF
--- a/comet/cli/compare.py
+++ b/comet/cli/compare.py
@@ -436,7 +436,7 @@ def compare_command() -> None:
         parser.error(
             "{} requires -r/--references or -d/--sacrebleu_dataset.".format(cfg.model)
         )
-
+    references = cfg.references if cfg.references is not None else None
     if not cfg.disable_cache:
         model.set_embedding_cache()
 


### PR DESCRIPTION
I was running the comet compare model for reference free model, and was getting error. Upon debugging this appeared like a bug to me, because the checks for reference model was already there. 
Command i used 
comet-compare -s src.ps -t hyp1.hi  hyp2.hi --model Unbabel/wmt22-cometkiwi-da
Error 
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.12/bin/comet-compare", line 8, in <module>
    sys.exit(compare_command())
             ^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/comet/cli/compare.py", line 501, in compare_command
    if references is not None:
       ^^^^^^^^^^
UnboundLocalError: cannot access local variable 'references' where it is not associated with a value