### PR TITLE
Add Transformers 5.x Compatibility

### DIFF
--- a/comet/encoders/bert.py
+++ b/comet/encoders/bert.py
@@ -168,15 +168,24 @@ class BERTEncoder(Encoder):
             Dict[str, torch.Tensor]: dictionary with 'sentemb', 'wordemb', 'all_layers'
                 and 'attention_mask'.
         """
-        last_hidden_states, pooler_output, all_layers = self.model(
+        output = self.model(
             input_ids=input_ids,
             token_type_ids=token_type_ids,
             attention_mask=attention_mask,
             output_hidden_states=True,
             return_dict=False,
         )
+        # Handle both transformers 4.x (3 values) and 5.x (2 values when add_pooling_layer=False)
+        if len(output) == 2:
+            last_hidden_states, all_layers = output
+            # Use CLS token as sentence embedding when no pooler output
+            sentemb = last_hidden_states[:, 0, :]
+        else:
+            last_hidden_states, pooler_output, all_layers = output
+            # Use pooler output if available, otherwise use CLS token
+            sentemb = pooler_output if pooler_output is not None else last_hidden_states[:, 0, :]
         return {
-            "sentemb": pooler_output,
+            "sentemb": sentemb,
             "wordemb": last_hidden_states,
             "all_layers": all_layers,
             "attention_mask": attention_mask,

--- a/comet/encoders/xlmr.py
+++ b/comet/encoders/xlmr.py
@@ -92,12 +92,17 @@ class XLMREncoder(BERTEncoder):
     def forward(
         self, input_ids: torch.Tensor, attention_mask: torch.Tensor, **kwargs
     ) -> Dict[str, torch.Tensor]:
-        last_hidden_states, _, all_layers = self.model(
+        output = self.model(
             input_ids=input_ids,
             attention_mask=attention_mask,
             output_hidden_states=True,
             return_dict=False,
         )
+        # Handle both transformers 4.x (3 values) and 5.x (2 values when add_pooling_layer=False)
+        if len(output) == 2:
+            last_hidden_states, all_layers = output
+        else:
+            last_hidden_states, _, all_layers = output
         return {
             "sentemb": last_hidden_states[:, 0, :],
             "wordemb": last_hidden_states,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ comet-mbr = 'comet.cli.mbr:mbr_command'
 python = "^3.8.0"
 sentencepiece = "^0.2.0"
 pandas = ">=1.4.1"
-transformers = "^4.17"
+transformers = ">=4.17"
 pytorch-lightning = "^2.0.0"
 jsonargparse = "3.13.1"
 torch = ">=1.6.0"
@@ -48,7 +48,7 @@ torchmetrics = "^0.10.2"
 sacrebleu = "^2.0.0"
 scipy = "^1.5.4"
 entmax = "^1.1"
-huggingface-hub = ">=0.19.3,<1.0"
+huggingface-hub = ">=0.19.3"
 protobuf = "^4.24.4"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
## Summary

This PR adds support for `transformers>=5.0.0` while maintaining full backward compatibility with transformers 4.x. The fix addresses a breaking change in how HuggingFace transformer models return outputs when `add_pooling_layer=False`.

## Problem

With `transformers==5.0.0`, COMET fails with the following error when scoring translations:

```
ValueError: not enough values to unpack (expected 3, got 2)
```

This occurs in `comet/encoders/xlmr.py:95` and `comet/encoders/bert.py:171` where the code expects 3 values from the model output tuple.

## Root Cause

In transformers 5.0, when models are created with `add_pooling_layer=False`, the output tuple format changed:

| Version | Output Format |
|---------|--------------|
| Transformers 4.x | `(last_hidden_states, pooler_output_or_None, hidden_states_tuple)` |
| Transformers 5.x | `(last_hidden_states, hidden_states_tuple)` |

The pooler output is now omitted entirely rather than being included as `None`.

## Solution

Updated the encoder `forward()` methods to dynamically handle both output formats by checking the tuple length:

```python
output = self.model(...)
if len(output) == 2:
    last_hidden_states, all_layers = output
else:
    last_hidden_states, _, all_layers = output
```

## Changes

- **`comet/encoders/xlmr.py`**: Updated `XLMREncoder.forward()` to handle both 2-value and 3-value output tuples
- **`comet/encoders/bert.py`**: Updated `BERTEncoder.forward()` with the same fix
- **`pyproject.toml`**: Relaxed version constraints:
  - `transformers = "^4.17"` → `transformers = ">=4.17"`
  - `huggingface-hub = ">=0.19.3,<1.0"` → `huggingface-hub = ">=0.19.3"`

## Testing

Tested with `Unbabel/wmt22-comet-da` model on sample translation pairs:

| Transformers Version | Status | System Score | Sentence Scores |
|---------------------|--------|--------------|-----------------|
| 4.57.3 | Pass | 0.9316 | [0.9714, 0.8917] |
| 5.0.0 | Pass | 0.9316 | [0.9714, 0.8917] |

Scores are identical, confirming backward compatibility and correctness.

----

The Transformers 5 release broke some of my scripts using Comet to benchmark translation scores due to the return value being different now, so worked on this PR (with Claude Code and Opus 4.5) to fix it.

I ran the translation scores on Spanish and checked everything still matched before and after. I've read and looked over the change and it looks ok to me, fairly minimal change that doesn't seem very disruptive to the code base.